### PR TITLE
Flips the orientation of text/images on the landing page

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -31,6 +31,9 @@ export default function Hero() {
     <MediaQuery maxWidth={904}>
       {mobile => (
         <Flex margin={mobile ? -15 : -39} padding={mobile ? 16 : 40} overflowX="hidden">
+          <Box left={-48} top={-24} overflow="hidden" position="relative" width={mobile ? '100%' : '60%'}>
+            <HeroDashboard />
+          </Box>
           <Box width={mobile ? '100%' : '40%'}>
             <Heading marginTop={0} size={500}>
               A new way to gather front-end feedback from your team.
@@ -58,9 +61,6 @@ export default function Hero() {
                 <span>Watch a video.</span>
               </Link>
             </Heading>
-          </Box>
-          <Box position="relative" left={mobile ? 0 : 39} width={mobile ? '100%' : '60%'}>
-            <HeroDashboard />
           </Box>
         </Flex>
       )}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ export default function IndexPage(props) {
     <Layout location={props.location}>
       <SEO title="Overview" />
       <Hero />
-      <RowReversal copyWritings={valueProps} flip={1} />
+      <RowReversal copyWritings={valueProps} />
       <Demo />
       <FeatureGrid />
       <DesignedForGitHub />


### PR DESCRIPTION
Notice that in the hero, the image appears on the left, and the text on the right. 

Currently on the default branch, the image is on the right, and the text is on the left.